### PR TITLE
Exclude records with severity 'Traffic' from dismissed charge petitions

### DIFF
--- a/dear_petition/petition/tests/factories.py
+++ b/dear_petition/petition/tests/factories.py
@@ -96,8 +96,8 @@ class OffenseFactory(factory.DjangoModelFactory):
 
 class OffenseRecordFactory(factory.DjangoModelFactory):
     offense = factory.SubFactory(OffenseFactory)
-    law = "20-141(J1)"
-    code = "4450"
+    law = "G.S. 14-223"
+    code = "5310"
     action = CHARGED
     severity = "MISDEMEANOR"
     description = "RESISTING PUBLIC OFFICER"

--- a/dear_petition/petition/tests/factories.py
+++ b/dear_petition/petition/tests/factories.py
@@ -99,8 +99,8 @@ class OffenseRecordFactory(factory.DjangoModelFactory):
     law = "20-141(J1)"
     code = "4450"
     action = CHARGED
-    severity = "TRAFFIC"
-    description = "SPEEDING(96 mph in a 70 mph zone) "
+    severity = "MISDEMEANOR"
+    description = "RESISTING PUBLIC OFFICER"
 
     class Meta:
         model = OffenseRecord

--- a/dear_petition/petition/types/dismissed.py
+++ b/dear_petition/petition/types/dismissed.py
@@ -8,7 +8,7 @@ def get_offense_records(batch, jurisdiction=""):
     qs = OffenseRecord.objects.filter(offense__ciprs_record__batch=batch)
     if jurisdiction:
         qs = qs.filter(offense__ciprs_record__jurisdiction=jurisdiction)
-    qs = qs.filter(build_query()).exclude(severity="INFRACTION")
+    qs = qs.filter(build_query()).exclude(severity__in=["INFRACTION", "TRAFFIC"])
     return qs.select_related("offense__ciprs_record__batch")
 
 

--- a/dear_petition/petition/types/tests/test_dismissed.py
+++ b/dear_petition/petition/types/tests/test_dismissed.py
@@ -36,9 +36,16 @@ def test_non_dismissed_disposition_method(batch, non_dismissed_offense):
 def test_infraction_severity_offense_record(batch, dismissed_offense):
     """Offense records with severity INFRACTION should be excluded."""
     infraction_record = OffenseRecordFactory(action="CHARGED", offense=dismissed_offense, severity="INFRACTION")
-    traffic_record = OffenseRecordFactory(action="CHARGED", offense=dismissed_offense, severity="TRAFFIC")
+    misdemeanor_record = OffenseRecordFactory(action="CHARGED", offense=dismissed_offense, severity="MISDEMEANOR")
     assert infraction_record not in batch.dismissed_offense_records()
-    assert traffic_record in batch.dismissed_offense_records()
+    assert misdemeanor_record in batch.dismissed_offense_records()
+
+def test_traffic_severity_offense_record(batch, dismissed_offense):
+    """Offense records with severity TRAFFIC should be excluded."""
+    traffic_record = OffenseRecordFactory(action="CHARGED", offense=dismissed_offense, severity="TRAFFIC")
+    misdemeanor_record = OffenseRecordFactory(action="CHARGED", offense=dismissed_offense, severity="MISDEMEANOR")
+    assert traffic_record not in batch.dismissed_offense_records()
+    assert misdemeanor_record in batch.dismissed_offense_records()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Change request:  "Exclude/ignore charges with “traffic” and “infraction” in the “severity” field regardless of the “disposition method: dismissal without leave.” We do not dismiss these charges so these charges should not populate on the forms."

This change excludes records with severity "traffic" from dismissed charge petition types ("AOC-CR-287"). Records with severity "Infraction" are already excluded.