### PR TITLE
Populate header 'File No(s)' field with the first offense file number

### DIFF
--- a/dear_petition/petition/export/forms.py
+++ b/dear_petition/petition/export/forms.py
@@ -84,9 +84,6 @@ class AOCFormCR287(PetitionForm):
     Petition and Orders of Expunction Under G.S. 15A-146(a) and G.S. 15A-146(a1) (Charge(s) Dismissed)
     https://www.nccourts.gov/assets/documents/forms/cr287.pdf
     """
-
-    MULTIPLE_FILE_NO_MSG = "Multiple - See Below"
-
     def build_form_context(self):
         self.map_file_no()
         self.map_header()
@@ -108,14 +105,11 @@ class AOCFormCR287(PetitionForm):
             self.data["Superior"] = Checkbox("")
 
     def map_file_no(self):
-        if self.petition.offense_records.count() > 1:
-            self.data["ConsJdgmntFileNum"] = self.MULTIPLE_FILE_NO_MSG
-        else:
-            offense_record = self.get_most_recent_record()
-            if offense_record:
-                self.data[
-                    "ConsJdgmntFileNum"
-                ] = offense_record.offense.ciprs_record.file_no
+        offense_record = self.get_most_recent_record()
+        if offense_record:
+            self.data[
+                "ConsJdgmntFileNum"
+            ] = offense_record.offense.ciprs_record.file_no
 
     def map_petitioner(self):
         self.data["PetitionerName"] = self.extra.get("name_petitioner")  # AOC-288

--- a/dear_petition/petition/export/forms.py
+++ b/dear_petition/petition/export/forms.py
@@ -64,6 +64,9 @@ class PetitionForm(metaclass=abc.ABCMeta):
 
         return qs
 
+    def get_first_record(self):
+        return self.get_ordered_offense_records().first()
+
     def get_most_recent_record(self):
         return self.get_ordered_offense_records().last()
 
@@ -105,7 +108,7 @@ class AOCFormCR287(PetitionForm):
             self.data["Superior"] = Checkbox("")
 
     def map_file_no(self):
-        offense_record = self.get_most_recent_record()
+        offense_record = self.get_first_record()
         if offense_record:
             self.data[
                 "ConsJdgmntFileNum"


### PR DESCRIPTION
Request:
File no. field should populate with the first charge’s file number/with charge number in the field immediately below “File No.(s)”. This rule always holds true except for additional charge forms. The field should never populate with “Multiple – See Below.” 

This changes removes “Multiple – See Below.” case from form AOC-CR-287, instead always populates with the latest offense  number if exists.