### PR TITLE
Fix checkbox bug to ensure it remains checked when pdf is downloaded

### DIFF
--- a/dear_petition/petition/export/writer.py
+++ b/dear_petition/petition/export/writer.py
@@ -51,5 +51,9 @@ class Writer:
             ):
                 key = annotation[self.ANNOT_FIELD_KEY][1:-1]
                 if key in self.data:
-                    annotation.update(pdfrw.PdfDict(**self.data[key]))
+                    fields = self.data[key]
+                    for key, value in fields.items():
+                        if key == 'AS':
+                            fields = {key: pdfrw.PdfName(value)}
+                    annotation.update(pdfrw.PdfDict(**fields))
         pdfrw.PdfWriter().write(self.output_path, self.template)


### PR DESCRIPTION
Request:
The program seems to appropriately recognize the difference between superior and district charges, but the check box option distinguishing between district and superior court is not marked when I download the form. 

Fix:
Use PDFName to convert a string value for checkbox into a PDF name
Found a hint at https://stackoverflow.com/questions/59730098/python-library-pdfrw-writes-to-annotations-that-remains-invisible-until-clicki#comment106393379_60123887

Manually tested and verified the checkbox in downloaded file remains checked